### PR TITLE
Update ggml-backend.c

### DIFF
--- a/ggml-backend.c
+++ b/ggml-backend.c
@@ -872,7 +872,7 @@ ggml_backend_sched_t ggml_backend_sched_new(ggml_backend_t * backends, int n_bac
     struct ggml_backend_sched * sched = malloc(sizeof(struct ggml_backend_sched));
     memset(sched, 0, sizeof(struct ggml_backend_sched));
 
-    fprintf(stderr, "ggml_backend_sched size: %lu KB\n", sizeof(struct ggml_backend_sched)/1024);
+    fprintf(stderr, "ggml_backend_sched size: %zu KB\n", sizeof(struct ggml_backend_sched)/1024);
 
     sched->n_backends = n_backends;
     for (int i = 0; i < n_backends; i++) {


### PR DESCRIPTION
Warning about %lu on 32-bit targets. Updated to %zu.